### PR TITLE
fix deprication for PHP 8.2

### DIFF
--- a/src/ScanCommand.php
+++ b/src/ScanCommand.php
@@ -26,6 +26,9 @@ class ScanCommand extends Command
     /** @var string */
     protected $target;
 
+    /** @var string Initial php version */
+    protected $after;
+	
     /** @var array */
     protected $excludeList = [];
 


### PR DESCRIPTION
Creation of dynamic property wapmorgan\PhpCodeFixer\ScanCommand::$after is deprecated