### PR TITLE
Closes #59

### DIFF
--- a/data/7.4.php
+++ b/data/7.4.php
@@ -30,4 +30,7 @@ return [
     'identifiers' => [
         'fn',
     ],
+    'variables' => [
+        '@curly_braces_dep',
+    ],
 ];

--- a/data/8.0.php
+++ b/data/8.0.php
@@ -146,5 +146,8 @@ return [
         'match',
         'mixed',
         'Stringable'
-    ]
+    ],
+    'variables' => [
+        '@curly_braces_rem'
+    ],
 ];

--- a/data/curly_braces_dep.php
+++ b/data/curly_braces_dep.php
@@ -1,0 +1,17 @@
+<?php
+namespace wapmorgan\PhpCodeFixer;
+
+/**
+ *
+ * @test 7.4
+ * @param array $usageTokens
+ * @return bool|string
+ */
+function curly_braces_dep(array $usageTokens){
+    if (count($usageTokens) === 0)
+        return false;
+
+    return 'Array and string offset access using curly braces is deprecated. '
+        .'Use ' . $usageTokens[0] . '[$idx] instead of ' . $usageTokens[0]
+        . '{$idx}.';
+}

--- a/data/curly_braces_rem.php
+++ b/data/curly_braces_rem.php
@@ -1,0 +1,16 @@
+<?php
+namespace wapmorgan\PhpCodeFixer;
+
+/**
+ *
+ * @test 8.0
+ * @param array $usageTokens
+ * @return bool|string
+ */
+function curly_braces_rem(array $usageTokens){
+    if (count($usageTokens) === 0)
+        return false;
+
+    return $usageTokens[0] . '[$idx] instead of ' . $usageTokens[0]
+        . '{$idx}.';
+}

--- a/src/PhpCodeFixer.php
+++ b/src/PhpCodeFixer.php
@@ -474,6 +474,74 @@ class PhpCodeFixer {
                     $used_variable[1], ($variable[0] != $used_variable[1] ? $variable[0] : null), $currentFile, $used_variable[2], $used_variable[3]);
             }
         }
+        // Solve Issue #59
+        $dec_var = false; // State Evaluating Var. Token.
+        $report_vr = ''; // Report Data Var.
+        $report_ln = ''; // Report Data Line.
+        $report_cn = ''; // Report Data Column.
+        foreach ($tokens as $i => $token) {
+            if (is_array($token)) {
+                if ($token[0] == T_VARIABLE) {
+                    if ( is_string($token[1]) ) { // Store Var Name
+                        $report_vr = $token[1];
+                    }
+                    $dec_var = true; // Evaluating Var On.
+                    if ( $report_ln === '' && $report_cn === '' ){
+                        // Store var location for report if needed.
+                        $report_ln = $token[2];
+                        $report_cn = $token[3];
+                    }
+                }
+            }else{
+                if ($dec_var === true) {
+                    if ($token === '{') { // Curly Barce Access.
+                        $dvar = $deprecated_varibales['@curly_braces_dep'];
+                        $rvar = $deprecated_varibales['@curly_braces_rem'];
+                        $tmp = array( $report_vr );
+                        // File Deprecation Report. PHP 7.4
+                        $result = self::callFunctionUsageChecker(
+                            ltrim( $dvar[0], '@' ),
+                            $report_vr,
+                            $tmp
+                        );
+                        if ($result) {
+                            $report->addIssue(
+                                $dvar[1],
+                                ReportIssue::CHANGED,
+                                ReportIssue::REMOVED_VARIABLE,
+                                'Usage: ' . $report_vr . '{}',
+                                is_string($result) ? $result : null,
+                                $currentFile,
+                                $report_ln,
+                                $report_cn
+                            );
+                        }
+                        // File Removal Report. PHP 8.0
+                        if ($result) {
+                            $result = self::callFunctionUsageChecker(
+                                ltrim( $rvar[0], '@' ),
+                                $report_vr,
+                                $tmp
+                            );
+                            $report->addIssue(
+                                $rvar[1],
+                                ReportIssue::REMOVED,
+                                ReportIssue::REMOVED_VARIABLE,
+                                'Usage: ' . $report_vr . '{}',
+                                is_string($result) ? $result : null,
+                                $currentFile,
+                                $report_ln,
+                                $report_cn
+                            );
+                        }
+                    }else{
+                        $dec_var = false; // Evaluating Var Off.
+                        $report_ln = ''; // Clear var location data.
+                        $report_cn = '';
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/tests/7.4.php
+++ b/tests/7.4.php
@@ -8,3 +8,9 @@ class fn
         ini_set('allow_url_include', true);
     }
 }
+
+/*
+ *  @See https://www.php.net/manual/en/migration74.deprecated.php
+ */
+// Deprecated: Array and string offset access using curly braces.
+$var{$idx};

--- a/tests/8.0.php
+++ b/tests/8.0.php
@@ -25,3 +25,10 @@ $p1 = new Point(4, 5);
 // Passing the separator after the array is no longer supported.
 $testArray = [1,2,3,4];
 $result = implode($testArray, "|");
+
+/*
+ *  @See https://www.php.net/manual/en/migration80.incompatible.php
+ */
+// Removed: Support for deprecated curly braces for offset access has been
+// removed.
+$var{$idx};


### PR DESCRIPTION
Adds checks for Array and string offset access syntax with curly braces.
Allows phpdd to detect this and issue the appropriate deprecation or removal warning.
Curly brace syntax was:
 - Deprecated in PHP 7.4.
 - Removed in PHP 8.0.