### PR TITLE
Closes #83

### DIFF
--- a/data/5.4.php
+++ b/data/5.4.php
@@ -4,5 +4,8 @@ return [
         'mcrypt_generic_end' => 'mcrypt_generic_deinit',
         'magic_quotes_runtime',
         'mysql_list_dbs',
-    ]
+    ],
+    'functions_usage' => [
+        'imagescale' => '@not_yet_implemented',
+    ],
 ];

--- a/data/not_yet_implemented.php
+++ b/data/not_yet_implemented.php
@@ -1,0 +1,21 @@
+<?php
+namespace wapmorgan\PhpCodeFixer;
+
+/**
+ *
+ * @test Any
+ * @param array $usageTokens
+ * @return bool|string
+ */
+
+function not_yet_implemented(array $usageTokens){
+    if (count($usageTokens) === 0)
+        return false;
+
+    // Make these Vars so that in the future this could work for more than
+    // just functions. See Issue #84
+    $Pfx = 'Function';
+    $Sfx = '()';
+    return "$Pfx " . $usageTokens[0][1]
+    . "$Sfx not yet implemented on this version of PHP.";
+}


### PR DESCRIPTION
Allows phpdd to catch use of not yet implemented functions in code designed to run on older versions of PHP. This will give developers the ability to know when changes break backward compatibility.